### PR TITLE
Update tuxtype.svg  to square

### DIFF
--- a/data/images/icons/tuxtype.svg
+++ b/data/images/icons/tuxtype.svg
@@ -11,7 +11,7 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="132"
-   height="117"
+   height="132"
    viewBox="0.008 -0.291 132 117"
    overflow="visible"
    enable-background="new 0.008 -0.291 132 117"


### PR DESCRIPTION
flatpak-builder wants icon images to be squares