### PR TITLE
Compilation2

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,6 +66,7 @@ tuxtype_SOURCES = 	\
 	convert_utf.c	\
 	editor.c	\
 	input_methods.c	\
+    globals.c \
 	laser.c		\
 	loaders.c	\
 	main.c		\

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,0 +1,11 @@
+#include "globals.h"
+//TTS Thread
+SDL_Thread *tts_thread;
+
+//TTS Word announcer Thread
+SDL_Thread *tts_announcer_thread;
+
+
+int  text_to_speech_status=0;
+
+struct braille_dict braille_key_value_map[100];

--- a/src/globals.h
+++ b/src/globals.h
@@ -182,8 +182,8 @@ extern int fs_res_y;
  *   DOUT( specialCode );  would add to stderr: "specialCode = 1\n" or
  *   whatever value specialCode had
  *   
- * - Use DEBUGCODE_TT if you need to do something more complicated like
- *   DEBUGCODE_TT { fprintf(stderr, "examining letter %d\n", x); }
+ * - Use DEBUGCODE if you need to do something more complicated like
+ *   DEBUGCODE { fprintf(stderr, "examining letter %d\n", x); }
  *   since DOUT(x) "x = 1\n" gives little information since x is used
  *   all over the place!
  */

--- a/src/globals.h
+++ b/src/globals.h
@@ -182,8 +182,8 @@ extern int fs_res_y;
  *   DOUT( specialCode );  would add to stderr: "specialCode = 1\n" or
  *   whatever value specialCode had
  *   
- * - Use DEBUGCODE if you need to do something more complicated like
- *   DEBUGCODE { fprintf(stderr, "examining letter %d\n", x); }
+ * - Use DEBUGCODE_TT if you need to do something more complicated like
+ *   DEBUGCODE_TT { fprintf(stderr, "examining letter %d\n", x); }
  *   since DOUT(x) "x = 1\n" gives little information since x is used
  *   all over the place!
  */

--- a/src/globals.h
+++ b/src/globals.h
@@ -84,10 +84,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MAX(x,y) ((x) > (y) ? (x) : (y))
 
 //TTS Thread
-SDL_Thread *tts_thread;
+extern SDL_Thread *tts_thread;
 
 //TTS Word announcer Thread
-SDL_Thread *tts_announcer_thread;
+extern SDL_Thread *tts_announcer_thread;
 
 #define FNLEN	256
 
@@ -130,7 +130,9 @@ struct braille_dict
 	wchar_t value_begin[100];
 	wchar_t value_middle[100];
 	wchar_t value_end[100];
-}braille_key_value_map[100];
+};
+
+extern struct braille_dict braille_key_value_map[100];
 
 
 /* Default values for game_option_type struct */
@@ -180,8 +182,8 @@ extern int fs_res_y;
  *   DOUT( specialCode );  would add to stderr: "specialCode = 1\n" or
  *   whatever value specialCode had
  *   
- * - Use DEBUGCODE if you need to do something more complicated like
- *   DEBUGCODE { fprintf(stderr, "examining letter %d\n", x); }
+ * - Use DEBUGCODE_TT if you need to do something more complicated like
+ *   DEBUGCODE_TT { fprintf(stderr, "examining letter %d\n", x); }
  *   since DOUT(x) "x = 1\n" gives little information since x is used
  *   all over the place!
  */

--- a/src/playgame.c
+++ b/src/playgame.c
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static int tux_max_width = 0;                // the max width of the images of tux
 static int number_max_w = 0;                 // the max width of a number image
 static int tts_announcer_switch = 1;
-int braille_letter_pos=0;
+static int braille_letter_pos=0;
 
 //static SDL_Surface* background = NULL;
 static SDL_Surface* level[NUM_LEVELS] = {NULL};

--- a/src/titlescreen.c
+++ b/src/titlescreen.c
@@ -34,18 +34,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "menu.h"
 
+
 /* --- Data Structure for Dirty Blitting --- */
 SDL_Rect srcupdate[MAX_UPDATES];
 SDL_Rect dstupdate[MAX_UPDATES];
 int numupdates = 0; // tracks how many blits to be done
 
-// Type needed for trans_wipe():
 struct blit {
     SDL_Surface *src;
     SDL_Rect *srcrect;
     SDL_Rect *dstrect;
     unsigned char type;
-} blits[MAX_UPDATES];
+};
+static struct blit blits[MAX_UPDATES];
+
 
 // Lessons available for play
 char **lesson_list_titles = NULL;
@@ -67,7 +69,7 @@ const float beak_pos[4]  = {0.36, 0.21, 0.27, 0.14};
 /* How long we show startup logo while files load, etc.: */
 const int logo_msec = 2000;
 
-SDL_Event event;
+//SDL_Event event;
 
 /* screen dimensions to which titlescreen graphics are currently rendered */
 int curr_res_x = -1;


### PR DESCRIPTION
When using t4k_common from git (https://github.com/tux4kids/t4kcommon.git, I have removed any other from my system to be sure), the code compilation runs ok, but 

the error message is:

`gcc -Wall -g -DDATA_PREFIX=\"/home/lacki/robota/tuxtyping/tuxtype/install-dev/share/tuxtype\" -DVAR_PREFIX=\"/home/lacki/robota/tuxtyping/tuxtype/install-dev/var/tuxtype\" -DCONF_PREFIX=\"/home/lacki/robota/tuxtyping/tuxtype/install-dev/etc/tuxtype\" -DIM_PREFIX=\"/home/lacki/robota/tuxtyping/tuxtype/install-dev/share/tuxtype/input_methods\" -DDEBUG -DVERSION=\"tuxtype-1.8.3\" -DSOUND -g -O2 -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT   -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT  -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -pthread -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/pixman-1  -I/usr/include/librsvg-2.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/x86_64-linux-gnu -pthread -I/usr/include/cairo -I/usr/include/freetype2 -I/usr/include/pixman-1  -I/usr/include/cairo -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/pixman-1  -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT  -I/usr/include/libxml2  -I/home/lacki/robota/tuxtyping/t4kcommon/lib/include -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/librsvg-2.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/x86_64-linux-gnu -pthread -I/usr/include/libxml2    -o tuxtype alphabet.o audio.o convert_utf.o editor.o input_methods.o laser.o loaders.o main.o mysetenv.o options.o pause.o pixels.o playgame.o practice.o scandir.o scripting.o SDL_extras.o setup.o snow.o theme.o titlescreen.o braille.o menu.o  -lm  -lSDL  -lSDL_image -lSDL  -lSDL_mixer -lSDL  -lSDL_Pango -lpango-1.0 -lgobject-2.0 -lglib-2.0 -lharfbuzz  -lrsvg-2 -lm -lgio-2.0 -lgdk_pixbuf-2.0 -lgobject-2.0 -lglib-2.0 -lcairo  -lcairo  -lSDL_net -lSDL  -lxml2  -lt4k_common -L/home/lacki/robota/tuxtyping/t4kcommon/lib/lib -lSDL_mixer -lSDL_net -lSDL_image -lSDL -lSDL_Pango -lpango-1.0 -lharfbuzz -lrsvg-2 -lm -lgio-2.0 -lgdk_pixbuf-2.0 -lgobject-2.0 -lglib-2.0 -lcairo -lxml2 
/usr/bin/ld: audio.o:/home/lacki/robota/tuxtyping/tuxtype/build/src/../../tuxtype_lacki/tuxtype/src/globals.h:133: multiple definition of `braille_key_value_map'; alphabet.o:/home/lacki/robota/tuxtyping/tuxtype/build/src/../../tuxtype_lacki/tuxtype/src/globals.h:133: first defined here
/usr/bin/ld: audio.o:/home/lacki/robota/tuxtyping/tuxtype/build/src/../../tuxtype_lacki/tuxtype/src/globals.h:90: multiple definition of `tts_announcer_thread'; alphabet.o:/home/lacki/robota/tuxtyping/tuxtype/build/src/../../tuxtype_lacki/tuxtype/src/globals.h:90: first defined here
/usr/bin/ld: audio.o:/home/lacki/robota/tuxtyping/tuxtype/build/src/../../tuxtype_lacki/tuxtype/src/globals.h:87: multiple definition of `tts_thread'; alphabet.o:/home/lacki/robota/tuxtyping/tuxtype/build/src/../../tuxtype_lacki/tuxtype/src/globals.h:87: first defined here
...................(lots of lines like that)......................
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:523: tuxtype] Error 1
make[2]: Leaving directory '/home/lacki/robota/tuxtyping/tuxtype/build/src'
make[1]: *** [Makefile:460: all-recursive] Error 1
make[1]: Leaving directory '/home/lacki/robota/tuxtyping/tuxtype/build'
make: *** [Makefile:395: all] Error 2
`